### PR TITLE
Fix scraping metrics

### DIFF
--- a/scrapy_prometheus.py
+++ b/scrapy_prometheus.py
@@ -75,10 +75,10 @@ class PrometheusStatsCollector(statscollectors.StatsCollector):
             try:
                 metric, created = metric_type(name, key, labels, registry=registry), True
             except ValueError as ex:
-                if not ex.args[0].startswith("Duplicated timeseries"):
-                    raise ex
-
-                return None, False
+                msg = ex.args[0]
+                if msg.startswith("Duplicated timeseries") or msg.startswith("Invalid metric name"):
+                    return None, False
+                raise ex
 
         else:
             metric, created = registry._names_to_collectors[name], False

--- a/scrapy_prometheus.py
+++ b/scrapy_prometheus.py
@@ -65,13 +65,21 @@ class PrometheusStatsCollector(statscollectors.StatsCollector):
 
     # noinspection PyProtectedMember
     def get_metric(self, key, metric_type, spider=None, labels=None):
+        labels = labels or {}
         prefix = self.crawler.settings.get('PROMETHEUS_METRIC_PREFIX', 'scrapy_prometheus')
         name = '%s_%s' % (prefix, key.replace('/', '_'))
 
         registry = self.get_registry(spider)
 
         if name not in registry._names_to_collectors:
-            metric, created = metric_type(name, key, labels, registry=registry), True
+            try:
+                metric, created = metric_type(name, key, labels, registry=registry), True
+            except ValueError as ex:
+                if not ex.args[0].startswith("Duplicated timeseries"):
+                    raise ex
+
+                return None, False
+
         else:
             metric, created = registry._names_to_collectors[name], False
             if not hasattr(metric_type, '__wrapped__') or hasattr(metric_type, '__wrapped__') and not isinstance(metric,


### PR DESCRIPTION
Two patches:

1. If labels are `None` prometheus_client throws the following error
```
cls = prometheus_client.metrics.Counter(scrapy_prometheus_log_count_INFO), labelnames = None

    def _validate_labelnames(cls, labelnames):
>       labelnames = tuple(labelnames)
E       TypeError: 'NoneType' object is not iterable

.venv/lib/python3.8/site-packages/prometheus_client/metrics.py:40: TypeError
```

Initialize them to an empty dict as a workaround.

2. If we try to create a metric that already exists catch the error
   detailing duplicate timeseries and supress it. Raise any other
   exception.